### PR TITLE
Improve input validation and logging

### DIFF
--- a/src/core/kill.rs
+++ b/src/core/kill.rs
@@ -1,37 +1,42 @@
-use frida::Device;
 use super::cli::ProcessArgs;
+use frida::Device;
 
 pub fn kill(device: &mut Device, args: &ProcessArgs) -> Vec<(String, u32)> {
     let processes = device.enumerate_processes().into_iter().collect::<Vec<_>>();
     let mut killed_processes = Vec::new();
 
-    let filtered_processes: Vec<(String, u32)> = processes.into_iter().filter_map(|process| {
-        if let Some(pid) = args.attach_pid {
-            if process.get_pid() == pid {
-                Some((process.get_name().to_string(), process.get_pid()))
+    let filtered_processes: Vec<(String, u32)> = processes
+        .into_iter()
+        .filter_map(|process| {
+            if let Some(pid) = args.attach_pid {
+                if process.get_pid() == pid {
+                    Some((process.get_name().to_string(), process.get_pid()))
+                } else {
+                    None
+                }
+            } else if let Some(attach_name) = &args.attach_name {
+                if process.get_name().to_lowercase() == attach_name.to_lowercase() {
+                    Some((process.get_name().to_string(), process.get_pid()))
+                } else {
+                    None
+                }
+            } else if let Some(target) = &args.target {
+                if process.get_name().to_lowercase() == target.to_lowercase() {
+                    Some((process.get_name().to_string(), process.get_pid()))
+                } else {
+                    None
+                }
             } else {
                 None
             }
-        } else if let Some(attach_name) = &args.attach_name {
-            if process.get_name().to_lowercase() == attach_name.to_lowercase() {
-                Some((process.get_name().to_string(), process.get_pid()))
-            } else {
-                None
-            }
-        } else if let Some(target) = &args.target {
-            if process.get_name().to_lowercase() == target.to_lowercase() {
-                Some((process.get_name().to_string(), process.get_pid()))
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    }).collect();
-    
+        })
+        .collect();
+
     for (name, pid) in filtered_processes {
-        device.kill(pid).unwrap();
-        killed_processes.push((name, pid));
+        match device.kill(pid) {
+            Ok(_) => killed_processes.push((name, pid)),
+            Err(e) => eprintln!("Failed to kill {} (pid {}): {}", name, pid, e),
+        }
     }
 
     killed_processes

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,13 +4,16 @@ mod kill;
 mod manager;
 mod ps;
 
-use crate::{gum::attach, util::{lengthed, highlight}};
+use crate::{
+    gum::attach,
+    util::{highlight, lengthed},
+};
 use actions::get_device;
 use clap::{CommandFactory, Parser};
 use cli::{Cli, Commands};
 use crossterm::style::Stylize;
 use manager::Manager;
-use std::{process::exit};
+use std::process::exit;
 
 pub fn execute_cli() {
     let cliparser = Cli::parse();
@@ -30,7 +33,7 @@ pub fn execute_cli() {
             let bin_name = "vlitz".to_string();
             clap_complete::generate(*shell, &mut cmd, bin_name, &mut std::io::stdout());
             std::process::exit(0);
-        },
+        }
         Commands::Attach(args) => {
             let device_opt = get_device(&_manager, &args.connection);
             if let Some(mut device) = device_opt {
@@ -44,7 +47,11 @@ pub fn execute_cli() {
         Commands::Ps(args) => {
             let device = get_device(&_manager, &args.connection);
             if let Some(device) = device {
-                println!("{} {}", "Device:".green(), device.get_id().replace("\"", "").green());
+                println!(
+                    "{} {}",
+                    "Device:".green(),
+                    device.get_id().replace("\"", "").green()
+                );
                 let processes = ps::ps(&device, args);
                 println!(
                     "{} {:<12} ({})",
@@ -53,8 +60,8 @@ pub fn execute_cli() {
                     processes.len(),
                 );
                 for process in processes {
-                    let process_name = if args.filter.is_some() {
-                        highlight(process.get_name(), args.filter.as_ref().unwrap())
+                    let process_name = if let Some(ref f) = args.filter {
+                        highlight(process.get_name(), f)
                     } else {
                         process.get_name().to_string()
                     };
@@ -78,9 +85,11 @@ pub fn execute_cli() {
                     println!("No processes killed");
                 } else {
                     for prc in killed_processes {
-                        println!("Killed process {} {}",
-                        format!("\"{}\"", prc.0).yellow(),
-                        format!("[{}]", prc.1.to_string()).blue());
+                        println!(
+                            "Killed process {} {}",
+                            format!("\"{}\"", prc.0).yellow(),
+                            format!("[{}]", prc.1.to_string()).blue()
+                        );
                     }
                     exit(0);
                 }

--- a/src/gum/commander.rs
+++ b/src/gum/commander.rs
@@ -1,12 +1,12 @@
 // src/gum/commander.rs
-use crossterm::style::Stylize;
 use crate::gum::{
-    filter::parse_filter_string, list::{list_functions, list_ranges, list_variables}
+    filter::parse_filter_string,
+    list::{list_functions, list_ranges, list_variables},
 };
+use crate::util::log_error;
+use crossterm::style::Stylize;
 
-use super::{
-    list::list_modules, navigator::Navigator, store::Store, vzdata::VzData
-};
+use super::{list::list_modules, navigator::Navigator, store::Store, vzdata::VzData};
 use frida::Script;
 use regex::Regex;
 use std::{fmt, vec};
@@ -57,12 +57,7 @@ struct SubCommand {
 }
 
 impl SubCommand {
-    fn new(
-        name: &str,
-        description: &str,
-        args: Vec<CommandArg>,
-        execute: CommandHandler,
-    ) -> Self {
+    fn new(name: &str, description: &str, args: Vec<CommandArg>, execute: CommandHandler) -> Self {
         Self {
             name: name.to_string(),
             aliases: Vec::new(),
@@ -118,17 +113,17 @@ pub struct Commander<'a, 'b> {
 
 impl<'a, 'b> Commander<'a, 'b> {
     pub fn new(script: &'a mut Script<'b>) -> Self {
-        let env_value = script.exports.call("get_env", None)
+        let env_value = script
+            .exports
+            .call("get_env", None)
             .expect("Failed to call get_env")
             .expect("Failed to get env value");
-        let env_arr = env_value.as_array().unwrap();
+        let env_arr = env_value.as_array().cloned().unwrap_or_default();
+        let os = env_arr.get(0).and_then(|v| v.as_str()).unwrap_or("");
+        let arch = env_arr.get(1).and_then(|v| v.as_str()).unwrap_or("");
         Commander {
             script,
-            env: format!(
-                "{} {}",
-                env_arr[0].as_str().unwrap_or(""),
-                env_arr[1].as_str().unwrap_or("")
-            ),
+            env: format!("{} {}", os, arch),
             field: Store::new("Field".to_string()),
             lib: Store::new("Lib".to_string()),
             navigator: Navigator::new(),
@@ -138,14 +133,10 @@ impl<'a, 'b> Commander<'a, 'b> {
                     "Debug functions",
                     vec!["d"],
                     vec![],
-                    vec![
-                        SubCommand::new(
-                            "exports",
-                            "List exports",
-                            vec![],
-                            |c, a| Commander::debug_exports(c, a),
-                        ).alias("e")
-                    ],
+                    vec![SubCommand::new("exports", "List exports", vec![], |c, a| {
+                        Commander::debug_exports(c, a)
+                    })
+                    .alias("e")],
                     None,
                 ),
                 Command::new(
@@ -168,9 +159,7 @@ impl<'a, 'b> Commander<'a, 'b> {
                     "select",
                     "Select data",
                     vec!["sel", "sl"],
-                    vec![
-                        CommandArg::required("selector", "Selector")
-                    ],
+                    vec![CommandArg::required("selector", "Selector")],
                     vec![],
                     Some(|c, a| Commander::select(c, a)),
                 ),
@@ -186,9 +175,7 @@ impl<'a, 'b> Commander<'a, 'b> {
                     "add",
                     "Add offset to selected data",
                     vec!["+"],
-                    vec![
-                        CommandArg::required("offset", "Offset")
-                    ],
+                    vec![CommandArg::required("offset", "Offset")],
                     vec![],
                     Some(|c, a| Commander::add(c, a)),
                 ),
@@ -196,9 +183,7 @@ impl<'a, 'b> Commander<'a, 'b> {
                     "sub",
                     "Subtract offset from selected data",
                     vec!["-"],
-                    vec![
-                        CommandArg::required("offset", "Offset")
-                    ],
+                    vec![CommandArg::required("offset", "Offset")],
                     vec![],
                     Some(|c, a| Commander::sub(c, a)),
                 ),
@@ -206,9 +191,7 @@ impl<'a, 'b> Commander<'a, 'b> {
                     "goto",
                     "Go to address",
                     vec!["go", ":"],
-                    vec![
-                        CommandArg::required("address", "Address")
-                    ],
+                    vec![CommandArg::required("address", "Address")],
                     vec![],
                     Some(|c, a| Commander::goto(c, a)),
                 ),
@@ -216,64 +199,80 @@ impl<'a, 'b> Commander<'a, 'b> {
                     "field",
                     "Field manipulation commands.",
                     vec!["fld", "f"],
-                    vec![
-                        CommandArg::optional("page", "Page number")
-                    ],
+                    vec![CommandArg::optional("page", "Page number")],
                     vec![
                         SubCommand::new(
                             "list",
                             "List fields with optional page number",
                             vec![CommandArg::optional("page", "Page number")],
                             |c, a| Commander::field_list(c, a),
-                        ).alias("ls").alias("l"),
+                        )
+                        .alias("ls")
+                        .alias("l"),
                         SubCommand::new(
                             "next",
                             "Go to next page of fields",
                             vec![CommandArg::optional("page", "Page number")],
                             |c, a| Commander::field_next(c, a),
-                        ).alias("n"),
+                        )
+                        .alias("n"),
                         SubCommand::new(
                             "prev",
                             "Go to previous page of fields",
                             vec![CommandArg::optional("page", "Page number")],
                             |c, a| Commander::field_prev(c, a),
-                        ).alias("p"),
+                        )
+                        .alias("p"),
                         SubCommand::new(
                             "sort",
                             "Sort fields by name",
                             vec![CommandArg::optional("type", "Sort type [addr]")],
                             |c, a| Commander::field_sort(c, a),
-                        ).alias("s"),
+                        )
+                        .alias("s"),
                         SubCommand::new(
                             "move",
                             "Move fields",
                             vec![
                                 CommandArg::required("from", "Index of data"),
-                                CommandArg::required("to", "Index of data")
+                                CommandArg::required("to", "Index of data"),
                             ],
                             |c, a| Commander::field_move(c, a),
-                        ).alias("mv"),
+                        )
+                        .alias("mv"),
                         SubCommand::new(
                             "remove",
                             "Remove data from field",
                             vec![
                                 CommandArg::required("index", "Index of data"),
-                                CommandArg::optional("count", "Count of data to remove (default: 1)")
+                                CommandArg::optional(
+                                    "count",
+                                    "Count of data to remove (default: 1)",
+                                ),
                             ],
                             |c, a| Commander::field_remove(c, a),
-                        ).alias("rm").alias("del").alias("delete"),
-                        SubCommand::new(
-                            "clear",
-                            "Clear all fields",
-                            vec![],
-                            |c, a| Commander::field_clear(c, a),
-                        ).alias("cls").alias("clr").alias("cl").alias("c"),
+                        )
+                        .alias("rm")
+                        .alias("del")
+                        .alias("delete"),
+                        SubCommand::new("clear", "Clear all fields", vec![], |c, a| {
+                            Commander::field_clear(c, a)
+                        })
+                        .alias("cls")
+                        .alias("clr")
+                        .alias("cl")
+                        .alias("c"),
                         SubCommand::new(
                             "filter",
                             "Filter fields",
-                            vec![CommandArg::required("filter", "Filter as filter expression")],
+                            vec![CommandArg::required(
+                                "filter",
+                                "Filter as filter expression",
+                            )],
                             |c, a| Commander::field_filter(c, a),
-                        ).alias("f").alias("filter"),
+                        )
+                        .alias("f")
+                        .alias("filter"),
                     ],
                     Some(|c, a| Commander::field_list(c, a)),
                 ),
@@ -296,55 +295,70 @@ impl<'a, 'b> Commander<'a, 'b> {
                             "List libraries with optional page number",
                             vec![CommandArg::optional("page", "Page number")],
                             |c, a| Commander::lib_list(c, a),
-                        ).alias("ls").alias("l"),
+                        )
+                        .alias("ls")
+                        .alias("l"),
                         SubCommand::new(
                             "next",
                             "Go to next page of libraries",
                             vec![CommandArg::optional("page", "Page number")],
                             |c, a| Commander::lib_next(c, a),
-                        ).alias("n"),
+                        )
+                        .alias("n"),
                         SubCommand::new(
                             "prev",
                             "Go to previous page of libraries",
                             vec![CommandArg::optional("page", "Page number")],
                             |c, a| Commander::lib_prev(c, a),
-                        ).alias("p"),
+                        )
+                        .alias("p"),
                         SubCommand::new(
                             "sort",
                             "Sort libraries by name",
                             vec![CommandArg::optional("type", "Sort type [addr]")],
                             |c, a| Commander::lib_sort(c, a),
-                        ).alias("s"),
+                        )
+                        .alias("s"),
                         SubCommand::new(
                             "move",
                             "Move data from one library to another",
                             vec![
                                 CommandArg::required("from", "Index of data"),
-                                CommandArg::required("to", "Index of data")
+                                CommandArg::required("to", "Index of data"),
                             ],
                             |c, a| Commander::lib_move(c, a),
-                        ).alias("mv"),
+                        )
+                        .alias("mv"),
                         SubCommand::new(
                             "remove",
                             "Remove data from library",
                             vec![
                                 CommandArg::required("index", "Index of data"),
-                                CommandArg::optional("count", "Count of data to remove (default: 1)")
+                                CommandArg::optional(
+                                    "count",
+                                    "Count of data to remove (default: 1)",
+                                ),
                             ],
                             |c, a| Commander::lib_remove(c, a),
-                        ).alias("rm").alias("del").alias("delete"),
-                        SubCommand::new(
-                            "clear",
-                            "Clear all data",
-                            vec![],
-                            |c, a| Commander::lib_clear(c, a),
-                        ).alias("cls").alias("clr").alias("cl").alias("c"),
+                        )
+                        .alias("rm")
+                        .alias("del")
+                        .alias("delete"),
+                        SubCommand::new("clear", "Clear all data", vec![], |c, a| {
+                            Commander::lib_clear(c, a)
+                        })
+                        .alias("cls")
+                        .alias("clr")
+                        .alias("cl")
+                        .alias("c"),
                         SubCommand::new(
                             "filter",
                             "Filter libraries",
                             vec![CommandArg::required("filter", "Filter expression")],
                             |c, a| Commander::lib_filter(c, a),
-                        ).alias("f").alias("filter"),
+                        )
+                        .alias("f")
+                        .alias("filter"),
                     ],
                     Some(|c, a| Commander::lib_list(c, a)),
                 ),
@@ -359,25 +373,40 @@ impl<'a, 'b> Commander<'a, 'b> {
                             "List all modules",
                             vec![CommandArg::optional("filter", "Filter modules")],
                             |c, a| Commander::list_modules(c, a),
-                        ).alias("mods").alias("md").alias("m"),
+                        )
+                        .alias("mods")
+                        .alias("md")
+                        .alias("m"),
                         SubCommand::new(
                             "ranges",
                             "List all ranges",
                             vec![CommandArg::optional("filter", "Filter ranges")],
                             |c, a| Commander::list_ranges(c, a),
-                        ).alias("ranges").alias("rngs").alias("rng").alias("r"),
+                        )
+                        .alias("ranges")
+                        .alias("rngs")
+                        .alias("rng")
+                        .alias("r"),
                         SubCommand::new(
                             "functions",
                             "List all functions",
                             vec![CommandArg::optional("filter", "Filter functions")],
                             |c, a| Commander::list_functions(c, a),
-                        ).alias("funcs").alias("fns").alias("fn").alias("f"),
+                        )
+                        .alias("funcs")
+                        .alias("fns")
+                        .alias("fn")
+                        .alias("f"),
                         SubCommand::new(
                             "variables",
                             "List all variables",
                             vec![CommandArg::optional("filter", "Filter variables")],
                             |c, a| Commander::list_variables(c, a),
-                        ).alias("vars").alias("vrs").alias("vr").alias("v"),
+                        )
+                        .alias("vars")
+                        .alias("vrs")
+                        .alias("vr")
+                        .alias("v"),
                     ],
                     None,
                 ),
@@ -398,16 +427,21 @@ impl<'a, 'b> Commander<'a, 'b> {
     }
 
     pub fn execute_command(&mut self, command: &str, args: &[&str]) -> bool {
-        if let Some(cmd) = self.commands.iter().find(|c| c.command == command || c.aliases.contains(&command.to_string())) {
+        if let Some(cmd) = self
+            .commands
+            .iter()
+            .find(|c| c.command == command || c.aliases.contains(&command.to_string()))
+        {
             if !cmd.subcommands.is_empty() {
                 if let Some((subcommand, sub_args)) = args.split_first() {
-                    if let Some(sub_cmd) = cmd.subcommands.iter().find(|s| 
+                    if let Some(sub_cmd) = cmd.subcommands.iter().find(|s| {
                         s.name == *subcommand || s.aliases.contains(&subcommand.to_string())
-                    ) {
+                    }) {
                         // Check required arguments for the subcommand
                         let required_args = sub_cmd.args.iter().filter(|a| a.required).count();
                         if sub_args.len() < required_args {
-                            println!("{} Expected at least {} arguments, got {}",
+                            println!(
+                                "{} Expected at least {} arguments, got {}",
                                 "Error:".red(),
                                 required_args,
                                 sub_args.len()
@@ -421,7 +455,11 @@ impl<'a, 'b> Commander<'a, 'b> {
                 if let Some(default_exec) = &cmd.default_execute {
                     return default_exec(self, args);
                 }
-                println!("{} {}", "No subcommand specified.".red(), format!("Use 'help {}' for more information.", command).dark_grey());
+                println!(
+                    "{} {}",
+                    "No subcommand specified.".red(),
+                    format!("Use 'help {}' for more information.", command).dark_grey()
+                );
                 return true;
             } else if let Some(exec) = &cmd.default_execute {
                 return exec(self, args);
@@ -434,17 +472,27 @@ impl<'a, 'b> Commander<'a, 'b> {
 
     fn help(&mut self, args: &[&str]) -> bool {
         if !args.is_empty() {
-            let command = self.commands.iter().find(|c| c.command == args[0] || c.aliases.contains(&args[0].to_string()));
+            let command = self
+                .commands
+                .iter()
+                .find(|c| c.command == args[0] || c.aliases.contains(&args[0].to_string()));
             if let Some(cmd) = command {
                 // Usage
-                let args_usage = cmd.args.iter()
-                .map(|arg| arg.to_string())
-                .collect::<Vec<_>>()
-                .join(" ");
-                println!("\n{} {}{}",
+                let args_usage = cmd
+                    .args
+                    .iter()
+                    .map(|arg| arg.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                println!(
+                    "\n{} {}{}",
                     "Usage:".green(),
                     cmd.command.clone().yellow(),
-                    if args_usage.is_empty() { "".to_string() } else { format!(" {}", args_usage) }
+                    if args_usage.is_empty() {
+                        "".to_string()
+                    } else {
+                        format!(" {}", args_usage)
+                    }
                 );
                 // Description
                 println!("{} {}", "Description:".green(), cmd.description);
@@ -453,7 +501,8 @@ impl<'a, 'b> Commander<'a, 'b> {
                     println!("\n{}", "Arguments:".green());
                     for arg in &cmd.args {
                         let required = if arg.required { " (required)" } else { "" };
-                        println!("  {:<15} {}{}",
+                        println!(
+                            "  {:<15} {}{}",
                             format!("{}:", arg.name),
                             arg.description,
                             required.yellow()
@@ -463,12 +512,13 @@ impl<'a, 'b> Commander<'a, 'b> {
 
                 // Aliases
                 if !cmd.aliases.is_empty() {
-                    println!("\n{} {}",
+                    println!(
+                        "\n{} {}",
                         "Aliases:".green(),
                         cmd.aliases.join(", ").dark_grey()
                     );
                 }
-                
+
                 // Subcommands
                 if !cmd.subcommands.is_empty() {
                     println!("\n{}", "Subcommands:".green());
@@ -478,38 +528,39 @@ impl<'a, 'b> Commander<'a, 'b> {
                         } else {
                             String::new()
                         };
-                        let sub_and_args = format!("{} {}", sub.name,
-                            sub.args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>().join(" ")
+                        let sub_and_args = format!(
+                            "{} {}",
+                            sub.name,
+                            sub.args
+                                .iter()
+                                .map(|arg| arg.to_string())
+                                .collect::<Vec<_>>()
+                                .join(" ")
                         );
                         if sub_and_args.len() > 15 {
-                            println!("  {}",
-                                sub_and_args
-                            );
-                            println!("  {} {}{}",
-                                " ".repeat(15),
-                                sub.description,
-                                aliases
-                            );
+                            println!("  {}", sub_and_args);
+                            println!("  {} {}{}", " ".repeat(15), sub.description, aliases);
                         } else {
-                            println!("  {:<15} {}{}",
-                                sub_and_args,
-                                sub.description,
-                                aliases
-                            );
+                            println!("  {:<15} {}{}", sub_and_args, sub.description, aliases);
                         }
                     }
                 }
-                
+
                 return true;
             }
-            
+
             println!("{} {}", "Unknown command:".red(), args[0]);
             true
         } else {
             // Show all commands
-            println!("  {}{} {}", "Command".green().bold(), " ".repeat(24 - "Command".len()), "Description".green().bold());
+            println!(
+                "  {}{} {}",
+                "Command".green().bold(),
+                " ".repeat(24 - "Command".len()),
+                "Description".green().bold()
+            );
             println!("  {:-<24} {:-<40}", "", "");
-            
+
             for cmd in &self.commands {
                 let aliases = if !cmd.aliases.is_empty() {
                     format!(" ({})", cmd.aliases.join(", ").dark_grey())
@@ -517,11 +568,13 @@ impl<'a, 'b> Commander<'a, 'b> {
                     String::new()
                 };
 
-                let args_usage = cmd.args.iter()
+                let args_usage = cmd
+                    .args
+                    .iter()
                     .map(|arg| arg.to_string())
                     .collect::<Vec<_>>()
                     .join(" ");
-                
+
                 let cmd_with_args: String = if args_usage.is_empty() {
                     cmd.command.clone().yellow().to_string()
                 } else {
@@ -531,16 +584,18 @@ impl<'a, 'b> Commander<'a, 'b> {
                 if !args_usage.is_empty() {
                     cmd_len += 1;
                 }
-                
+
                 if cmd_len < 24 {
-                    println!("  {}{} {}{}",
+                    println!(
+                        "  {}{} {}{}",
                         cmd_with_args,
                         " ".repeat(24 - cmd_len),
                         cmd.description,
                         aliases
                     );
                 } else {
-                    println!("  {}\n  {}{}",
+                    println!(
+                        "  {}\n  {}{}",
                         cmd_with_args,
                         " ".repeat(24),
                         format!("{}{}", cmd.description, aliases)
@@ -549,12 +604,14 @@ impl<'a, 'b> Commander<'a, 'b> {
 
                 if !cmd.subcommands.is_empty() {
                     for subcmd in &cmd.subcommands {
-                        let aliases = if !subcmd.aliases.is_empty(){
+                        let aliases = if !subcmd.aliases.is_empty() {
                             format!(" ({})", subcmd.aliases.join(", ").dark_grey())
                         } else {
                             String::new()
                         };
-                        let args_usage = subcmd.args.iter()
+                        let args_usage = subcmd
+                            .args
+                            .iter()
                             .map(|arg| arg.to_string())
                             .collect::<Vec<_>>()
                             .join(" ");
@@ -568,7 +625,8 @@ impl<'a, 'b> Commander<'a, 'b> {
                             subcmd_len += 1;
                         }
                         if (subcmd_len + cmd.command.len() + 1) < 24 {
-                            println!("  {}{}{} {}{}",
+                            println!(
+                                "  {}{}{} {}{}",
                                 " ".repeat(cmd.command.len() + 1),
                                 subcmd_with_args,
                                 " ".repeat(24 - subcmd_len - cmd.command.len() - 1),
@@ -576,7 +634,8 @@ impl<'a, 'b> Commander<'a, 'b> {
                                 aliases
                             );
                         } else {
-                            println!("  {}{}\n    {}{}{}",
+                            println!(
+                                "  {}{}\n    {}{}{}",
                                 " ".repeat(cmd.command.len() + 1),
                                 subcmd_with_args,
                                 " ".repeat(24 - 1),
@@ -588,8 +647,12 @@ impl<'a, 'b> Commander<'a, 'b> {
                 }
             }
 
-            println!("\nType \'{} {}\' for more information", "help".yellow().bold(), "[command]".bold());
-            
+            println!(
+                "\nType \'{} {}\' for more information",
+                "help".yellow().bold(),
+                "[command]".bold()
+            );
+
             true
         }
     }
@@ -603,7 +666,10 @@ impl<'a, 'b> Commander<'a, 'b> {
         let re = Regex::new(r"^(?:(\w+):)?(.+)$").expect("Regex compilation failed");
         if let Some(caps) = re.captures(s) {
             let explicit_store_capture = caps.get(1);
-            let selector_str = caps.get(2).ok_or_else(|| "No selector provided".to_string())?.as_str();
+            let selector_str = caps
+                .get(2)
+                .ok_or_else(|| "No selector provided".to_string())?
+                .as_str();
             let selector_is_numeric = selector_str.chars().all(char::is_numeric);
 
             if let Some(store_match) = explicit_store_capture {
@@ -620,7 +686,10 @@ impl<'a, 'b> Commander<'a, 'b> {
                         .map_err(|e| format!("Selector '{}': search in explicitly specified 'field' store failed: {}", selector_str, e))
                         .and_then(|data| if data.is_empty() { Err(format!("Selector '{}': no items found in explicitly specified 'field' store.", selector_str)) } else { Ok(data) })
                 } else {
-                    Err(format!("Unknown explicitly specified store: {}", store_name))
+                    Err(format!(
+                        "Unknown explicitly specified store: {}",
+                        store_name
+                    ))
                 }
             } else {
                 // NO store specified, default to "lib" with potential fallback for NUMERIC selectors
@@ -677,10 +746,8 @@ impl<'a, 'b> Commander<'a, 'b> {
                     println!("Multiple data found for selector: {}", selector);
                     true
                 }
-            },
-            Err(_) => {
-                true
             }
+            Err(_) => true,
         }
     }
 
@@ -689,39 +756,50 @@ impl<'a, 'b> Commander<'a, 'b> {
         true
     }
 
-    fn parse_number(s: &str) -> u64 {
+    fn parse_number(s: &str) -> Result<u64, String> {
         if s.starts_with("0x") || s.starts_with("0X") {
-            u64::from_str_radix(&s[2..], 16).unwrap_or(0)
+            u64::from_str_radix(&s[2..], 16).map_err(|_| format!("Invalid hex number: {}", s))
         } else {
-            s.parse::<u64>().unwrap_or(0)
+            s.parse::<u64>()
+                .map_err(|_| format!("Invalid number: {}", s))
         }
     }
 
     fn add(&mut self, args: &[&str]) -> bool {
-        let offset = args.get(0).map(|s| Self::parse_number(s)).unwrap_or(0);
-        self.navigator.add(offset);
+        match args.get(0).map(|s| Self::parse_number(s)) {
+            Some(Ok(offset)) => self.navigator.add(offset),
+            Some(Err(e)) => log_error(&format!("Invalid offset: {}", e)),
+            None => log_error("Offset argument required"),
+        }
         true
     }
 
     fn sub(&mut self, args: &[&str]) -> bool {
-        let offset = args.get(0).map(|s| Self::parse_number(s)).unwrap_or(0);
-        self.navigator.sub(offset);
+        match args.get(0).map(|s| Self::parse_number(s)) {
+            Some(Ok(offset)) => self.navigator.sub(offset),
+            Some(Err(e)) => log_error(&format!("Invalid offset: {}", e)),
+            None => log_error("Offset argument required"),
+        }
         true
     }
 
     fn goto(&mut self, args: &[&str]) -> bool {
-        let address = args.get(0).map(|s| Self::parse_number(s))
-            .expect("Missing address");
-        self.navigator.goto(address);
+        match args.get(0).map(|s| Self::parse_number(s)) {
+            Some(Ok(addr)) => self.navigator.goto(addr),
+            Some(Err(e)) => log_error(&format!("Invalid address: {}", e)),
+            None => log_error("Address argument required"),
+        }
         true
     }
 
     fn field_list(&mut self, args: &[&str]) -> bool {
-        let page = args.get(0).and_then(|s| s.parse::<u32>().ok()).unwrap_or(0);
-        if let Some(page_num) = page.checked_sub(1) {
-            println!("{}", self.field.to_string(Some(page_num as usize)));
-        } else {
-            println!("{}", self.field.to_string(None));
+        match args.get(0) {
+            Some(v) => match v.parse::<usize>() {
+                Ok(p) if p > 0 => println!("{}", self.field.to_string(Some(p - 1))),
+                Ok(_) => println!("{}", self.field.to_string(None)),
+                Err(_) => log_error(&format!("Invalid page number: {}", v)),
+            },
+            None => println!("{}", self.field.to_string(None)),
         }
         true
     }
@@ -729,8 +807,13 @@ impl<'a, 'b> Commander<'a, 'b> {
     fn field_next(&mut self, args: &[&str]) -> bool {
         let (current_page, total_pages) = self.field.get_page_info();
         if current_page != total_pages {
-            let page = args.get(0).and_then(|s| s.parse::<u32>().ok()).unwrap_or(1);
-            self.field.next_page(page.try_into().unwrap());
+            match args.get(0) {
+                Some(v) => match v.parse::<u32>() {
+                    Ok(p) => self.field.next_page(p.try_into().unwrap_or(1)),
+                    Err(_) => log_error(&format!("Invalid page number: {}", v)),
+                },
+                None => self.field.next_page(1),
+            }
         }
         println!("{}", self.field.to_string(None));
         true
@@ -739,8 +822,13 @@ impl<'a, 'b> Commander<'a, 'b> {
     fn field_prev(&mut self, args: &[&str]) -> bool {
         let (current_page, _) = self.field.get_page_info();
         if current_page != 1 {
-            let page = args.get(0).and_then(|s| s.parse::<u32>().ok()).unwrap_or(1);
-            self.field.prev_page(page.try_into().unwrap());
+            match args.get(0) {
+                Some(v) => match v.parse::<u32>() {
+                    Ok(p) => self.field.prev_page(p.try_into().unwrap_or(1)),
+                    Err(_) => log_error(&format!("Invalid page number: {}", v)),
+                },
+                None => self.field.prev_page(1),
+            }
         }
         println!("{}", self.field.to_string(None));
         true
@@ -755,17 +843,36 @@ impl<'a, 'b> Commander<'a, 'b> {
     }
 
     fn field_move(&mut self, args: &[&str]) -> bool {
-        let from = args.get(0).and_then(|s| s.parse::<usize>().ok()).unwrap_or(0);
-        let to = args.get(1).and_then(|s| s.parse::<usize>().ok()).unwrap_or(0);
-        self.field.move_data(from, to);
+        let from_res = args
+            .get(0)
+            .ok_or("Missing from index")
+            .and_then(|v| v.parse::<usize>().map_err(|_| "Invalid from index"));
+        let to_res = args
+            .get(1)
+            .ok_or("Missing to index")
+            .and_then(|v| v.parse::<usize>().map_err(|_| "Invalid to index"));
+        match (from_res, to_res) {
+            (Ok(from), Ok(to)) => self.field.move_data(from, to),
+            (Err(e), _) | (_, Err(e)) => log_error(&format!("Field move error: {}", e)),
+        }
         println!("{}", self.field.to_string(None));
         true
     }
 
     fn field_remove(&mut self, args: &[&str]) -> bool {
-        let index = args.get(0).and_then(|s| s.parse::<usize>().ok()).unwrap_or(0);
-        let count = args.get(1).and_then(|s| s.parse::<usize>().ok()).unwrap_or(1);
-        self.field.remove_data(index, count);
+        let index_res = args
+            .get(0)
+            .ok_or("Missing index")
+            .and_then(|v| v.parse::<usize>().map_err(|_| "Invalid index"));
+        let count_res = args
+            .get(1)
+            .unwrap_or(&"1")
+            .parse::<usize>()
+            .map_err(|_| "Invalid count");
+        match (index_res, count_res) {
+            (Ok(idx), Ok(count)) => self.field.remove_data(idx, count),
+            (Err(e), _) | (_, Err(e)) => log_error(&format!("Field remove error: {}", e)),
+        }
         println!("{}", self.field.to_string(None));
         true
     }
@@ -775,25 +882,27 @@ impl<'a, 'b> Commander<'a, 'b> {
         println!("{}", self.field.to_string(None));
         true
     }
-    
+
     fn field_filter(&mut self, args: &[&str]) -> bool {
         let filter_arg = args.get(0).map_or("", |v| v);
-        let filter = parse_filter_string(filter_arg)
-            .unwrap_or_else(|_| {
-                println!("Failed to parse filter string: {}", filter_arg);
-                return Vec::new();
-            });
-        self.field.filter(filter);
-        println!("{}", self.field.to_string(None));
+        match parse_filter_string(filter_arg) {
+            Ok(filter) => {
+                self.field.filter(filter);
+                println!("{}", self.field.to_string(None));
+            }
+            Err(e) => log_error(&format!("Failed to parse filter string: {}", e)),
+        }
         true
     }
 
     fn lib_list(&mut self, args: &[&str]) -> bool {
-        let page = args.get(0).and_then(|s| s.parse::<u32>().ok()).unwrap_or(0);
-        if let Some(page_num) = page.checked_sub(1) {
-            println!("{}", self.lib.to_string(Some(page_num as usize)));
-        } else {
-            println!("{}", self.lib.to_string(None));
+        match args.get(0) {
+            Some(v) => match v.parse::<usize>() {
+                Ok(p) if p > 0 => println!("{}", self.lib.to_string(Some(p - 1))),
+                Ok(_) => println!("{}", self.lib.to_string(None)),
+                Err(_) => log_error(&format!("Invalid page number: {}", v)),
+            },
+            None => println!("{}", self.lib.to_string(None)),
         }
         true
     }
@@ -801,8 +910,13 @@ impl<'a, 'b> Commander<'a, 'b> {
     fn lib_next(&mut self, args: &[&str]) -> bool {
         let (current_page, total_pages) = self.lib.get_page_info();
         if current_page != total_pages {
-            let page = args.get(0).and_then(|s| s.parse::<u32>().ok()).unwrap_or(1);
-            self.lib.next_page(page.try_into().unwrap());
+            match args.get(0) {
+                Some(v) => match v.parse::<u32>() {
+                    Ok(p) => self.lib.next_page(p.try_into().unwrap_or(1)),
+                    Err(_) => log_error(&format!("Invalid page number: {}", v)),
+                },
+                None => self.lib.next_page(1),
+            }
         }
         println!("{}", self.lib.to_string(None));
         true
@@ -811,8 +925,13 @@ impl<'a, 'b> Commander<'a, 'b> {
     fn lib_prev(&mut self, args: &[&str]) -> bool {
         let (current_page, _) = self.lib.get_page_info();
         if current_page != 1 {
-            let page = args.get(0).and_then(|s| s.parse::<u32>().ok()).unwrap_or(1);
-            self.lib.prev_page(page.try_into().unwrap());
+            match args.get(0) {
+                Some(v) => match v.parse::<u32>() {
+                    Ok(p) => self.lib.prev_page(p.try_into().unwrap_or(1)),
+                    Err(_) => log_error(&format!("Invalid page number: {}", v)),
+                },
+                None => self.lib.prev_page(1),
+            }
         }
         println!("{}", self.lib.to_string(None));
         true
@@ -827,41 +946,83 @@ impl<'a, 'b> Commander<'a, 'b> {
     }
 
     fn lib_save(&mut self, args: &[&str]) -> bool {
-        let datas = self.field.get_data_by_selection(args.get(0).unwrap_or(&""));
-        if let Ok(datas) = datas {
-            self.lib.add_datas(datas.into_iter().map(|d| {
-                let mut d = d.clone();
-                match &mut d {
-                    VzData::Pointer(p) => {p.base.is_saved = true;},
-                    VzData::Module(m) => {m.base.is_saved = true;},
-                    VzData::Range(r) => {r.base.is_saved = true;},
-                    VzData::Function(f) => {f.base.is_saved = true;},
-                    VzData::Variable(v) => {v.base.is_saved = true;},
-                    VzData::JavaClass(c) => {c.base.is_saved = true;},
-                    VzData::JavaMethod(m) => {m.base.is_saved = true;},
-                    VzData::ObjCClass(c) => {c.base.is_saved = true;},
-                    VzData::ObjCMethod(m) => {m.base.is_saved = true;},
-                    VzData::Thread(t) => {t.base.is_saved = true;},
+        let selected = if let Some(sel) = args.get(0) {
+            match self.field.get_data_by_selection(sel) {
+                Ok(data) if !data.is_empty() => Ok(data),
+                Ok(_) => {
+                    log_error(&format!("No data found for selector: {}", sel));
+                    return true;
                 }
-                d
-            }).collect());
+                Err(e) => {
+                    log_error(&format!("Selector error: {}", e));
+                    return true;
+                }
+            }
+        } else if let Some(nav_data) = self.navigator.get_data() {
+            Ok(vec![nav_data])
+        } else {
+            log_error("No selector provided and navigator is empty");
+            return true;
+        };
+
+        if let Ok(datas) = selected {
+            self.lib.add_datas(
+                datas
+                    .into_iter()
+                    .map(|d| {
+                        let mut d = d.clone();
+                        match &mut d {
+                            VzData::Pointer(p) => p.base.is_saved = true,
+                            VzData::Module(m) => m.base.is_saved = true,
+                            VzData::Range(r) => r.base.is_saved = true,
+                            VzData::Function(f) => f.base.is_saved = true,
+                            VzData::Variable(v) => v.base.is_saved = true,
+                            VzData::JavaClass(c) => c.base.is_saved = true,
+                            VzData::JavaMethod(m) => m.base.is_saved = true,
+                            VzData::ObjCClass(c) => c.base.is_saved = true,
+                            VzData::ObjCMethod(m) => m.base.is_saved = true,
+                            VzData::Thread(t) => t.base.is_saved = true,
+                        }
+                        d
+                    })
+                    .collect(),
+            );
         }
         println!("{}", self.lib.to_string(None));
         true
     }
 
     fn lib_move(&mut self, args: &[&str]) -> bool {
-        let from = args.get(0).and_then(|s| s.parse::<usize>().ok()).unwrap_or(0);
-        let to = args.get(1).and_then(|s| s.parse::<usize>().ok()).unwrap_or(0);
-        self.lib.move_data(from, to);
+        let from_res = args
+            .get(0)
+            .ok_or("Missing from index")
+            .and_then(|v| v.parse::<usize>().map_err(|_| "Invalid from index"));
+        let to_res = args
+            .get(1)
+            .ok_or("Missing to index")
+            .and_then(|v| v.parse::<usize>().map_err(|_| "Invalid to index"));
+        match (from_res, to_res) {
+            (Ok(from), Ok(to)) => self.lib.move_data(from, to),
+            (Err(e), _) | (_, Err(e)) => log_error(&format!("Lib move error: {}", e)),
+        }
         println!("{}", self.lib.to_string(None));
         true
     }
 
     fn lib_remove(&mut self, args: &[&str]) -> bool {
-        let index = args.get(0).and_then(|s| s.parse::<usize>().ok()).unwrap_or(0);
-        let count = args.get(1).and_then(|s| s.parse::<usize>().ok()).unwrap_or(1);
-        self.lib.remove_data(index, count);
+        let index_res = args
+            .get(0)
+            .ok_or("Missing index")
+            .and_then(|v| v.parse::<usize>().map_err(|_| "Invalid index"));
+        let count_res = args
+            .get(1)
+            .unwrap_or(&"1")
+            .parse::<usize>()
+            .map_err(|_| "Invalid count");
+        match (index_res, count_res) {
+            (Ok(idx), Ok(count)) => self.lib.remove_data(idx, count),
+            (Err(e), _) | (_, Err(e)) => log_error(&format!("Lib remove error: {}", e)),
+        }
         println!("{}", self.lib.to_string(None));
         true
     }
@@ -874,23 +1035,25 @@ impl<'a, 'b> Commander<'a, 'b> {
 
     fn lib_filter(&mut self, args: &[&str]) -> bool {
         let filter_arg = args.get(0).map_or("", |v| v);
-        let filter = parse_filter_string(filter_arg)
-            .unwrap_or_else(|_| {
-                println!("Failed to parse filter string: {}", filter_arg);
-                return Vec::new();
-            });
-        self.lib.filter(filter);
-        println!("{}", self.lib.to_string(None));
+        match parse_filter_string(filter_arg) {
+            Ok(filter) => {
+                self.lib.filter(filter);
+                println!("{}", self.lib.to_string(None));
+            }
+            Err(e) => log_error(&format!("Failed to parse filter string: {}", e)),
+        }
         true
     }
 
     fn list_modules(&mut self, _args: &[&str]) -> bool {
         let filter = _args.get(0).map(|s| s.to_string());
-        let modules = list_modules(&mut self.script, filter.as_deref())
-        .unwrap_or(vec![])
-        .into_iter()
-        .map(|m| VzData::Module(m))
-            .collect::<Vec<_>>();
+        let modules = match list_modules(&mut self.script, filter.as_deref()) {
+            Ok(m) => m.into_iter().map(VzData::Module).collect::<Vec<_>>(),
+            Err(e) => {
+                log_error(&format!("List modules error: {}", e));
+                return true;
+            }
+        };
         self.field.clear_data();
         self.field.add_datas(modules);
         println!("{}", self.field.to_string(None));
@@ -900,11 +1063,13 @@ impl<'a, 'b> Commander<'a, 'b> {
     fn list_ranges(&mut self, _args: &[&str]) -> bool {
         let protect = _args.get(0).map(|s| s.to_string());
         let filter = _args.get(1).map(|s| s.to_string());
-        let ranges = list_ranges(&mut self.script, protect.as_deref(), filter.as_deref())
-        .unwrap_or(vec![])
-        .into_iter()
-        .map(|r| VzData::Range(r))
-            .collect::<Vec<_>>();
+        let ranges = match list_ranges(&mut self.script, protect.as_deref(), filter.as_deref()) {
+            Ok(r) => r.into_iter().map(VzData::Range).collect::<Vec<_>>(),
+            Err(e) => {
+                log_error(&format!("List ranges error: {}", e));
+                return true;
+            }
+        };
         self.field.clear_data();
         self.field.add_datas(ranges);
         println!("{}", self.field.to_string(None));
@@ -918,39 +1083,42 @@ impl<'a, 'b> Commander<'a, 'b> {
         let module = match res {
             Ok(data) => {
                 if data.is_empty() {
-                    eprintln!("No data selected");
+                    log_error("No data selected");
                     return true;
                 } else if let Some(VzData::Module(m)) = data.first() {
                     filter = _args.get(1).map(|s| s.to_string());
                     m.clone()
                 } else {
-                    eprintln!("Selected data is not a module");
+                    log_error("Selected data is not a module");
                     return true;
                 }
-            },
-            Err(e) => { 
-                match self.navigator.get_data() {
-                    Some(vz_data_from_navigator) => {
-                        if let VzData::Module(m) = vz_data_from_navigator {
-                            filter = _args.get(0).map(|s| s.to_string());
-                            m.clone()
-                        } else {
-                            eprintln!("Selector error: {}. Navigator data is not a VzModule.", e);
-                            return true;
-                        }
-                    }
-                    None => {
-                        eprintln!("Selector error: {}. Navigator has no data.", e);
+            }
+            Err(e) => match self.navigator.get_data() {
+                Some(vz_data_from_navigator) => {
+                    if let VzData::Module(m) = vz_data_from_navigator {
+                        filter = _args.get(0).map(|s| s.to_string());
+                        m.clone()
+                    } else {
+                        log_error(&format!(
+                            "Selector error: {}. Navigator data is not a VzModule.",
+                            e
+                        ));
                         return true;
                     }
                 }
+                None => {
+                    log_error(&format!("Selector error: {}. Navigator has no data.", e));
+                    return true;
+                }
             },
         };
-        let functions = list_functions(&mut self.script, module, filter.as_deref())
-        .unwrap_or(vec![])
-        .into_iter()
-        .map(|f| VzData::Function(f))
-            .collect::<Vec<_>>();
+        let functions = match list_functions(&mut self.script, module, filter.as_deref()) {
+            Ok(fns) => fns.into_iter().map(VzData::Function).collect::<Vec<_>>(),
+            Err(e) => {
+                log_error(&format!("List functions error: {}", e));
+                return true;
+            }
+        };
         self.field.clear_data();
         self.field.add_datas(functions);
         println!("{}", self.field.to_string(None));
@@ -964,39 +1132,42 @@ impl<'a, 'b> Commander<'a, 'b> {
         let module = match res {
             Ok(data) => {
                 if data.is_empty() {
-                    eprintln!("No data selected");
+                    log_error("No data selected");
                     return true;
                 } else if let Some(VzData::Module(m)) = data.first() {
                     filter = _args.get(1).map(|s| s.to_string());
                     m.clone()
                 } else {
-                    eprintln!("Selected data is not a module");
+                    log_error("Selected data is not a module");
                     return true;
                 }
-            },
-            Err(e) => { 
-                match self.navigator.get_data() {
-                    Some(vz_data_from_navigator) => {
-                        if let VzData::Module(m) = vz_data_from_navigator {
-                            filter = _args.get(0).map(|s| s.to_string());
-                            m.clone()
-                        } else {
-                            eprintln!("Selector error: {}. Navigator data is not a VzModule.", e);
-                            return true;
-                        }
-                    }
-                    None => {
-                        eprintln!("Selector error: {}. Navigator has no data.", e);
+            }
+            Err(e) => match self.navigator.get_data() {
+                Some(vz_data_from_navigator) => {
+                    if let VzData::Module(m) = vz_data_from_navigator {
+                        filter = _args.get(0).map(|s| s.to_string());
+                        m.clone()
+                    } else {
+                        log_error(&format!(
+                            "Selector error: {}. Navigator data is not a VzModule.",
+                            e
+                        ));
                         return true;
                     }
                 }
+                None => {
+                    log_error(&format!("Selector error: {}. Navigator has no data.", e));
+                    return true;
+                }
             },
         };
-        let variables = list_variables(&mut self.script, module, filter.as_deref())
-        .unwrap_or(vec![])
-        .into_iter()
-        .map(|v| VzData::Variable(v))
-            .collect::<Vec<_>>();
+        let variables = match list_variables(&mut self.script, module, filter.as_deref()) {
+            Ok(vars) => vars.into_iter().map(VzData::Variable).collect::<Vec<_>>(),
+            Err(e) => {
+                log_error(&format!("List variables error: {}", e));
+                return true;
+            }
+        };
         self.field.clear_data();
         self.field.add_datas(variables);
         println!("{}", self.field.to_string(None));
@@ -1009,8 +1180,10 @@ impl<'a, 'b> Commander<'a, 'b> {
     }
 
     fn debug_exports(&mut self, _args: &[&str]) -> bool {
-        let exports = self.script.list_exports().unwrap();
-        println!("{:?}", &exports);
+        match self.script.list_exports() {
+            Ok(exports) => println!("{:?}", &exports),
+            Err(e) => log_error(&format!("Failed to list exports: {}", e)),
+        }
         true
     }
 }

--- a/src/gum/list.rs
+++ b/src/gum/list.rs
@@ -1,85 +1,107 @@
 // src/gum/list.rs
-use frida::Script;
-use super::vzdata::{string_to_u64, VzBase, VzDataType, VzModule, VzRange, VzFunction, VzVariable};
-use serde_json::{json, Value};
+use super::vzdata::{string_to_u64, VzBase, VzDataType, VzFunction, VzModule, VzRange, VzVariable};
 use crate::gum::filter::parse_filter_string_to_json;
+use frida::Script;
+use serde_json::{json, Value};
 
 pub fn list_modules(script: &mut Script, filter: Option<&str>) -> Result<Vec<VzModule>, String> {
     let filter = parse_filter_string_to_json(filter.unwrap_or(""))
-        .unwrap_or(json!([]));
-    let modules = script.exports
+        .map_err(|e| format!("Filter parse error: {}", e))?;
+    let modules = script
+        .exports
         .call("list_modules", Some(json!([filter])))
         .map_err(|e| e.to_string())?;
-    let binding = modules.unwrap();
-    let mod_arr = binding.as_array()
+    let binding = modules.ok_or_else(|| "No modules returned".to_string())?;
+    let mod_arr = binding
+        .as_array()
         .ok_or_else(|| "Expected object of modules".to_string())?;
-    mod_arr.iter()
+    mod_arr
+        .iter()
         .map(|m: &Value| {
-            let obj = m.as_object()
+            let obj = m
+                .as_object()
                 .ok_or_else(|| "Expected object of module".to_string())?;
-            
-            let name = obj.get("name")
+
+            let name = obj
+                .get("name")
                 .ok_or_else(|| "Expected name of module".to_string())?
                 .as_str()
                 .ok_or_else(|| "Expected string name of module".to_string())?
                 .to_string();
-            let address = obj.get("address")
+            let address = obj
+                .get("address")
                 .ok_or_else(|| "Expected address of module".to_string())?
                 .as_str()
                 .ok_or_else(|| "Expected string address of module".to_string())?
                 .to_string();
-            let size = obj.get("size")
+            let size = obj
+                .get("size")
                 .ok_or_else(|| "Expected size of module".to_string())?
                 .as_u64()
                 .ok_or_else(|| "Expected u64 size of module".to_string())?;
 
+            let address = string_to_u64(&address)
+                .map_err(|e| format!("Module address parse error: {}", e))?;
             Ok(VzModule {
                 base: VzBase {
                     data_type: VzDataType::Module,
                     is_saved: false,
                 },
                 name,
-                address: string_to_u64(&address),
+                address,
                 size: size as usize,
             })
         })
         .collect::<Result<Vec<_>, _>>()
 }
 
-pub fn list_ranges(script: &mut Script, protect: Option<&str>, filter: Option<&str>) -> Result<Vec<VzRange>, String> {
+pub fn list_ranges(
+    script: &mut Script,
+    protect: Option<&str>,
+    filter: Option<&str>,
+) -> Result<Vec<VzRange>, String> {
     let protect = protect.unwrap_or("---");
     let filter = parse_filter_string_to_json(filter.unwrap_or(""))
-        .unwrap_or(json!([]));
-    let ranges = script.exports
+        .map_err(|e| format!("Filter parse error: {}", e))?;
+    let ranges = script
+        .exports
         .call("list_ranges", Some(json!([protect, filter])))
         .map_err(|e| e.to_string())?;
-    let binding = ranges.unwrap();
-    let range_arr = binding.as_array()
+    let binding = ranges.ok_or_else(|| "No ranges returned".to_string())?;
+    let range_arr = binding
+        .as_array()
         .ok_or_else(|| "Expected object of ranges".to_string())?;
-    range_arr.iter()
+    range_arr
+        .iter()
         .map(|r: &Value| {
-            let obj = r.as_object()
+            let obj = r
+                .as_object()
                 .ok_or_else(|| "Expected object of range".to_string())?;
-            let address = obj.get("address")
+            let address = obj
+                .get("address")
                 .ok_or_else(|| "Expected address of range".to_string())?
                 .as_str()
                 .ok_or_else(|| "Expected string address of range".to_string())?
                 .to_string();
-            let size = obj.get("size")
+            let size = obj
+                .get("size")
                 .ok_or_else(|| "Expected size of range".to_string())?
                 .as_u64()
                 .ok_or_else(|| "Expected u64 size of range".to_string())?;
-            let protection = obj.get("protection")
+            let protection = obj
+                .get("protection")
                 .ok_or_else(|| "Expected protection of range".to_string())?
                 .as_str()
                 .ok_or_else(|| "Expected string protection of range".to_string())?
                 .to_string();
+            let address =
+                string_to_u64(&address).map_err(|e| format!("Range address parse error: {}", e))?;
             Ok(VzRange {
                 base: VzBase {
                     data_type: VzDataType::Range,
                     is_saved: false,
                 },
-                address: string_to_u64(&address),
+                address,
                 size: size as usize,
                 protection,
             })
@@ -87,82 +109,108 @@ pub fn list_ranges(script: &mut Script, protect: Option<&str>, filter: Option<&s
         .collect::<Result<Vec<_>, _>>()
 }
 
-pub fn list_functions(script: &mut Script, md: VzModule, filter: Option<&str>) -> Result<Vec<VzFunction>, String> {
+pub fn list_functions(
+    script: &mut Script,
+    md: VzModule,
+    filter: Option<&str>,
+) -> Result<Vec<VzFunction>, String> {
     let filter = parse_filter_string_to_json(filter.unwrap_or(""))
-        .unwrap_or(json!([]));
-    let functions = script.exports
+        .map_err(|e| format!("Filter parse error: {}", e))?;
+    let functions = script
+        .exports
         .call("list_functions", Some(json!([md.address, filter])))
         .map_err(|e| e.to_string())?;
-    let binding = functions.unwrap();
-    let func_arr = binding.as_array()
+    let binding = functions.ok_or_else(|| "No functions returned".to_string())?;
+    let func_arr = binding
+        .as_array()
         .ok_or_else(|| "Expected object of functions".to_string())?;
-    func_arr.iter()
+    func_arr
+        .iter()
         .map(|f: &Value| {
-            let obj = f.as_object()
+            let obj = f
+                .as_object()
                 .ok_or_else(|| "Expected object of function".to_string())?;
-            let name = obj.get("name")
+            let name = obj
+                .get("name")
                 .ok_or_else(|| "Expected name of function".to_string())?
                 .as_str()
                 .ok_or_else(|| "Expected string name of function".to_string())?
                 .to_string();
-            let address = obj.get("address")
+            let address = obj
+                .get("address")
                 .ok_or_else(|| "Expected address of function".to_string())?
                 .as_str()
                 .ok_or_else(|| "Expected string address of function".to_string())?
                 .to_string();
-            let module = obj.get("module")
+            let module = obj
+                .get("module")
                 .ok_or_else(|| "Expected module of function".to_string())?
                 .as_str()
                 .ok_or_else(|| "Expected string module of function".to_string())?
                 .to_string();
+            let address = string_to_u64(&address)
+                .map_err(|e| format!("Function address parse error: {}", e))?;
             Ok(VzFunction {
                 base: VzBase {
                     data_type: VzDataType::Function,
                     is_saved: false,
                 },
                 name,
-                address: string_to_u64(&address),
+                address,
                 module,
             })
         })
         .collect::<Result<Vec<_>, _>>()
 }
 
-pub fn list_variables(script: &mut Script, md: VzModule, filter: Option<&str>) -> Result<Vec<VzVariable>, String> {
+pub fn list_variables(
+    script: &mut Script,
+    md: VzModule,
+    filter: Option<&str>,
+) -> Result<Vec<VzVariable>, String> {
     let filter = parse_filter_string_to_json(filter.unwrap_or(""))
-        .unwrap_or(json!([]));
-    let variables = script.exports
+        .map_err(|e| format!("Filter parse error: {}", e))?;
+    let variables = script
+        .exports
         .call("list_variables", Some(json!([md.address, filter])))
         .map_err(|e| e.to_string())?;
-    let binding = variables.unwrap();
-    let var_arr = binding.as_array()
+    let binding = variables.ok_or_else(|| "No variables returned".to_string())?;
+    let var_arr = binding
+        .as_array()
         .ok_or_else(|| "Expected object of variables".to_string())?;
-    var_arr.iter()
+    var_arr
+        .iter()
         .map(|v: &Value| {
-            let obj = v.as_object()
+            let obj = v
+                .as_object()
                 .ok_or_else(|| "Expected object of variable".to_string())?;
-            let name = obj.get("name")
+            let name = obj
+                .get("name")
                 .ok_or_else(|| "Expected name of variable".to_string())?
                 .as_str()
                 .ok_or_else(|| "Expected string name of variable".to_string())?
                 .to_string();
-            let address = obj.get("address")
+            let address = obj
+                .get("address")
                 .ok_or_else(|| "Expected address of variable".to_string())?
                 .as_str()
                 .ok_or_else(|| "Expected string address of variable".to_string())?
                 .to_string();
-            let module = obj.get("module")
+            let module = obj
+                .get("module")
                 .ok_or_else(|| "Expected module of variable".to_string())?
                 .as_str()
                 .ok_or_else(|| "Expected string module of variable".to_string())?
                 .to_string();
+            let address = string_to_u64(&address)
+                .map_err(|e| format!("Variable address parse error: {}", e))?;
             Ok(VzVariable {
                 base: VzBase {
                     data_type: VzDataType::Variable,
                     is_saved: false,
                 },
                 name,
-                address: string_to_u64(&address),
+                address,
                 module,
             })
         })

--- a/src/gum/memory.rs
+++ b/src/gum/memory.rs
@@ -1,96 +1,139 @@
-use serde_json::{json, Value};
 use frida::Script;
+use serde_json::{json, Value};
 
 pub fn readbyte(script: &mut Script, addr: u64) -> Result<u8, String> {
-    let data = script.exports
+    let data = script
+        .exports
         .call("reader_byte", Some(json!([addr])))
         .map_err(|e| e.to_string())?;
-    let binding = data.unwrap();
-    Ok(binding.as_u64().unwrap() as u8)
+    let binding = data.ok_or_else(|| "No data returned".to_string())?;
+    let value = binding.as_u64().ok_or_else(|| "Invalid byte".to_string())?;
+    Ok(value as u8)
 }
 
 pub fn readshort(script: &mut Script, addr: u64) -> Result<i16, String> {
-    let data = script.exports
+    let data = script
+        .exports
         .call("reader_short", Some(json!([addr])))
         .map_err(|e| e.to_string())?;
-    let binding = data.unwrap();
-    Ok(binding.as_i64().unwrap() as i16)
+    let binding = data.ok_or_else(|| "No data returned".to_string())?;
+    let value = binding
+        .as_i64()
+        .ok_or_else(|| "Invalid short".to_string())?;
+    Ok(value as i16)
 }
 
 pub fn readushort(script: &mut Script, addr: u64) -> Result<u16, String> {
-    let data = script.exports
+    let data = script
+        .exports
         .call("reader_ushort", Some(json!([addr])))
         .map_err(|e| e.to_string())?;
-    let binding = data.unwrap();
-    Ok(binding.as_u64().unwrap() as u16)
+    let binding = data.ok_or_else(|| "No data returned".to_string())?;
+    let value = binding
+        .as_u64()
+        .ok_or_else(|| "Invalid ushort".to_string())?;
+    Ok(value as u16)
 }
 
 pub fn readint(script: &mut Script, addr: u64) -> Result<i32, String> {
-    let data = script.exports
+    let data = script
+        .exports
         .call("reader_int", Some(json!([addr])))
         .map_err(|e| e.to_string())?;
-    let binding = data.unwrap();
-    Ok(binding.as_i64().unwrap() as i32)
+    let binding = data.ok_or_else(|| "No data returned".to_string())?;
+    let value = binding.as_i64().ok_or_else(|| "Invalid int".to_string())?;
+    Ok(value as i32)
 }
 
 pub fn readuint(script: &mut Script, addr: u64) -> Result<u32, String> {
-    let data = script.exports
+    let data = script
+        .exports
         .call("reader_uint", Some(json!([addr])))
         .map_err(|e| e.to_string())?;
-    let binding = data.unwrap();
-    Ok(binding.as_u64().unwrap() as u32)
+    let binding = data.ok_or_else(|| "No data returned".to_string())?;
+    let value = binding.as_u64().ok_or_else(|| "Invalid uint".to_string())?;
+    Ok(value as u32)
 }
 
 pub fn readlong(script: &mut Script, addr: u64) -> Result<i64, String> {
-    let data = script.exports
+    let data = script
+        .exports
         .call("reader_long", Some(json!([addr])))
         .map_err(|e| e.to_string())?;
-    let binding = data.unwrap();
-    Ok(binding.as_i64().unwrap())
+    let binding = data.ok_or_else(|| "No data returned".to_string())?;
+    let value = binding.as_i64().ok_or_else(|| "Invalid long".to_string())?;
+    Ok(value)
 }
 
 pub fn readulong(script: &mut Script, addr: u64) -> Result<u64, String> {
-    let data = script.exports
+    let data = script
+        .exports
         .call("reader_ulong", Some(json!([addr])))
         .map_err(|e| e.to_string())?;
-    let binding = data.unwrap();
-    Ok(binding.as_u64().unwrap())
+    let binding = data.ok_or_else(|| "No data returned".to_string())?;
+    let value = binding
+        .as_u64()
+        .ok_or_else(|| "Invalid ulong".to_string())?;
+    Ok(value)
 }
 
 pub fn readfloat(script: &mut Script, addr: u64) -> Result<f32, String> {
-    let data = script.exports
+    let data = script
+        .exports
         .call("reader_float", Some(json!([addr])))
         .map_err(|e| e.to_string())?;
-    let binding = data.unwrap();
-    Ok(binding.as_f64().unwrap() as f32)
+    let binding = data.ok_or_else(|| "No data returned".to_string())?;
+    let value = binding
+        .as_f64()
+        .ok_or_else(|| "Invalid float".to_string())?;
+    Ok(value as f32)
 }
 
 pub fn readdouble(script: &mut Script, addr: u64) -> Result<f64, String> {
-    let data = script.exports
+    let data = script
+        .exports
         .call("reader_double", Some(json!([addr])))
         .map_err(|e| e.to_string())?;
-    let binding = data.unwrap();
-    Ok(binding.as_f64().unwrap())
+    let binding = data.ok_or_else(|| "No data returned".to_string())?;
+    let value = binding
+        .as_f64()
+        .ok_or_else(|| "Invalid double".to_string())?;
+    Ok(value)
 }
 
 pub fn readstring(script: &mut Script, addr: u64) -> Result<String, String> {
-    let data = script.exports
+    let data = script
+        .exports
         .call("reader_string", Some(json!([addr])))
         .map_err(|e| e.to_string())?;
-    let binding = data.unwrap();
-    Ok(binding.as_str().unwrap().to_string())
+    let binding = data.ok_or_else(|| "No data returned".to_string())?;
+    let value = binding
+        .as_str()
+        .ok_or_else(|| "Invalid string".to_string())?;
+    Ok(value.to_string())
 }
 
 pub fn readbytes(script: &mut Script, addr: u64, len: usize) -> Result<Vec<u8>, String> {
-    let data = script.exports
+    let data = script
+        .exports
         .call("reader_bytes", Some(json!([addr, len])))
         .map_err(|e| e.to_string())?;
-    let binding = data.unwrap();
-    Ok(binding.as_array().unwrap().iter().map(|v| v.as_u64().unwrap() as u8).collect())
+    let binding = data.ok_or_else(|| "No data returned".to_string())?;
+    let arr = binding
+        .as_array()
+        .ok_or_else(|| "Invalid byte array".to_string())?;
+    arr.iter()
+        .map(|v| {
+            v.as_u64()
+                .ok_or_else(|| "Invalid byte value".to_string())
+                .map(|n| n as u8)
+        })
+        .collect()
 }
 
 pub fn writebyte(script: &mut Script, addr: u64, value: u8) -> Result<(), String> {
-    script.exports
+    script
+        .exports
         .call("writer_byte", Some(json!([addr, value])))
         .map_err(|e| e.to_string())?;
     Ok(())

--- a/src/gum/mod.rs
+++ b/src/gum/mod.rs
@@ -2,13 +2,13 @@
 mod handler;
 mod session;
 
-pub mod vzdata;
-pub mod store;
 pub mod commander;
-pub mod navigator;
-pub mod list;
 pub mod filter;
+pub mod list;
 pub mod memory;
+pub mod navigator;
+pub mod store;
+pub mod vzdata;
 
 use std::process::exit;
 
@@ -19,10 +19,18 @@ use handler::Handler;
 use session::session_manager;
 
 fn attach_pid<'a>(device: &'a Device, pid: u32) -> (frida::Session<'a>, u32) {
-    (device.attach(pid).unwrap_or_else(|e| {
-        println!("{} {} ({})", "Failed to attach process:".red(), pid.to_string().yellow(), e);
-        exit(0);
-    }), pid)
+    (
+        device.attach(pid).unwrap_or_else(|e| {
+            println!(
+                "{} {} ({})",
+                "Failed to attach process:".red(),
+                pid.to_string().yellow(),
+                e
+            );
+            exit(0);
+        }),
+        pid,
+    )
 }
 
 pub fn attach(device: &mut Device, args: &TargetArgs) {
@@ -33,7 +41,11 @@ pub fn attach(device: &mut Device, args: &TargetArgs) {
             .find(|p| p.get_pid() == _pid)
             .map(|p| p.get_pid())
             .unwrap_or_else(|| {
-                println!("{} {}", "Process not found:".red(), _pid.to_string().yellow());
+                println!(
+                    "{} {}",
+                    "Process not found:".red(),
+                    _pid.to_string().yellow()
+                );
                 exit(0);
             });
         attach_pid(device, pid)
@@ -41,7 +53,12 @@ pub fn attach(device: &mut Device, args: &TargetArgs) {
         let pid = device
             .spawn(file, &frida::SpawnOptions::new())
             .unwrap_or_else(|e| {
-                println!("{} {} ({})", "Failed to spawn process:".red(), file.to_string().yellow(), e);
+                println!(
+                    "{} {} ({})",
+                    "Failed to spawn process:".red(),
+                    file.to_string().yellow(),
+                    e
+                );
                 exit(0);
             });
         attach_pid(device, pid)
@@ -52,7 +69,11 @@ pub fn attach(device: &mut Device, args: &TargetArgs) {
             .find(|p| p.get_name().to_lowercase() == name.to_lowercase())
             .map(|p| p.get_pid())
             .unwrap_or_else(|| {
-                println!("{} {}", "Process not found:".red(), name.to_string().yellow());
+                println!(
+                    "{} {}",
+                    "Process not found:".red(),
+                    name.to_string().yellow()
+                );
                 exit(0);
             });
         attach_pid(device, pid)
@@ -63,7 +84,11 @@ pub fn attach(device: &mut Device, args: &TargetArgs) {
             .find(|p| p.get_name().to_lowercase() == name.to_lowercase())
             .map(|p| p.get_pid())
             .unwrap_or_else(|| {
-                println!("{} {}", "Process not found:".red(), name.to_string().yellow());
+                println!(
+                    "{} {}",
+                    "Process not found:".red(),
+                    name.to_string().yellow()
+                );
                 exit(0);
             });
         attach_pid(device, pid)
@@ -74,7 +99,11 @@ pub fn attach(device: &mut Device, args: &TargetArgs) {
             .find(|p| p.get_name().to_lowercase() == name.to_lowercase())
             .map(|p| p.get_pid())
             .unwrap_or_else(|| {
-                println!("{} {}", "Process not found:".red(), name.to_string().yellow());
+                println!(
+                    "{} {}",
+                    "Process not found:".red(),
+                    name.to_string().yellow()
+                );
                 exit(0);
             });
         attach_pid(device, pid)
@@ -115,8 +144,13 @@ pub fn attach(device: &mut Device, args: &TargetArgs) {
     session_manager(&session, &mut script, pid);
 
     if !session.is_detached() {
-        script.unload().unwrap();
-        session.detach().unwrap();
-        println!("{}", "Session detached.".yellow().bold());
+        if let Err(e) = script.unload() {
+            eprintln!("Failed to unload script: {}", e);
+        }
+        if let Err(e) = session.detach() {
+            eprintln!("Failed to detach session: {}", e);
+        } else {
+            println!("{}", "Session detached.".yellow().bold());
+        }
     }
 }

--- a/src/gum/session.rs
+++ b/src/gum/session.rs
@@ -1,19 +1,19 @@
 // src/gum/session.rs
+use super::commander::Commander;
+use crossterm::{cursor, style::Stylize, terminal, ExecutableCommand};
 use frida::{Script, Session};
 use regex::Regex;
 use std::{
     io::{stdin, stdout, Write},
-    sync::{Arc, atomic::{AtomicBool, Ordering}},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
-use crossterm::{
-    ExecutableCommand,
-    terminal, cursor, style::{Stylize}
-};
-use super::{commander::Commander};
 
 fn parse_command(input: &str) -> Vec<String> {
-    let re = Regex::new(r#"("[^"]*")|('[^']*')|(\S+)"#).unwrap();
-    
+    let re = Regex::new(r#"("[^"]*")|('[^']*')|(\S+)"#).expect("Failed to compile command regex");
+
     re.find_iter(input)
         .map(|m| m.as_str().to_string())
         .collect()
@@ -23,17 +23,34 @@ pub fn session_manager(session: &Session, script: &mut Script<'_>, pid: u32) {
     let mut commander = Commander::new(script);
     let version = env!("CARGO_PKG_VERSION");
     let title = format!("vlitz v{}", version);
-    stdout().execute(terminal::SetTitle(title)).unwrap();
-    stdout().execute(terminal::Clear(terminal::ClearType::All)).unwrap();
-    stdout().execute(cursor::MoveTo(0, 0)).unwrap();
-    println!("{}", format!("Welcome to Vlitz v{} - A Strong Dynamic Debugger", version).green());
-    println!("Attached on: [{}] {}", pid.to_string().blue(), commander.env.clone().cyan());
-    println!("{}", "Type 'help' for more information about available commands.".yellow());
+    if let Err(e) = stdout().execute(terminal::SetTitle(title)) {
+        eprintln!("Failed to set terminal title: {}", e);
+    }
+    if let Err(e) = stdout().execute(terminal::Clear(terminal::ClearType::All)) {
+        eprintln!("Failed to clear terminal: {}", e);
+    }
+    if let Err(e) = stdout().execute(cursor::MoveTo(0, 0)) {
+        eprintln!("Failed to move cursor: {}", e);
+    }
+    println!(
+        "{}",
+        format!("Welcome to Vlitz v{} - A Strong Dynamic Debugger", version).green()
+    );
+    println!(
+        "Attached on: [{}] {}",
+        pid.to_string().blue(),
+        commander.env.clone().cyan()
+    );
+    println!(
+        "{}",
+        "Type 'help' for more information about available commands.".yellow()
+    );
     let running = Arc::new(AtomicBool::new(true));
     let r = running.clone();
     ctrlc::set_handler(move || {
         r.store(false, Ordering::SeqCst);
-    }).unwrap_or_else(|e| {
+    })
+    .unwrap_or_else(|e| {
         eprintln!("Error setting Ctrl-C handler: {}", e);
         std::process::exit(1);
     });
@@ -43,15 +60,19 @@ pub fn session_manager(session: &Session, script: &mut Script<'_>, pid: u32) {
             break;
         }
         let write_str = format!("{}>", commander.navigator);
-        stdout().write(write_str.as_bytes()).unwrap();
-        stdout().flush().unwrap();
+        if let Err(e) = stdout().write(write_str.as_bytes()) {
+            eprintln!("Write error: {}", e);
+        }
+        if let Err(e) = stdout().flush() {
+            eprintln!("Flush error: {}", e);
+        }
         let mut input = String::new();
         let bytes_read = stdin().read_line(&mut input);
         match bytes_read {
             Ok(0) => {
                 println!("\n{}", "Ctrl + D detected. Exiting...".yellow());
                 break;
-            },
+            }
             Ok(_) => (), // Successfully read some bytes
             Err(e) => {
                 println!("Error reading input: {}", e);
@@ -70,7 +91,13 @@ pub fn session_manager(session: &Session, script: &mut Script<'_>, pid: u32) {
         let command = args.remove(0);
         match command.as_str() {
             _ => {
-                if !commander.execute_command(command.as_str(), args.iter().map(|s| s.as_str()).collect::<Vec<_>>().as_slice()) {
+                if !commander.execute_command(
+                    command.as_str(),
+                    args.iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .as_slice(),
+                ) {
                     break;
                 }
             }

--- a/src/gum/store.rs
+++ b/src/gum/store.rs
@@ -1,9 +1,12 @@
 // src/gum/store.rs
 
+use super::{
+    filter::{FilterOperator, FilterSegment, FilterValue, LogicalOperator},
+    vzdata::{VzData, VzDataType},
+};
 use crate::util::lengthed;
-use super::{filter::{FilterSegment, FilterValue, FilterOperator, LogicalOperator}, vzdata::{VzData, VzDataType}};
-use std::fmt::Debug; // Required for format!("{:?}") on VzDataType
 use crossterm::style::Stylize;
+use std::fmt::Debug; // Required for format!("{:?}") on VzDataType
 use std::{collections::BTreeSet, fmt};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -15,12 +18,19 @@ pub enum SelectorType {
 impl fmt::Display for SelectorType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SelectorType::Indices(indices) => write!(f, "{}", indices.iter().map(|i| i.to_string()).collect::<Vec<String>>().join(" ")),
+            SelectorType::Indices(indices) => write!(
+                f,
+                "{}",
+                indices
+                    .iter()
+                    .map(|i| i.to_string())
+                    .collect::<Vec<String>>()
+                    .join(" ")
+            ),
             SelectorType::All => write!(f, "all"),
         }
     }
 }
-
 
 pub struct Store {
     pub name: String,
@@ -94,7 +104,9 @@ impl Store {
         let (_, total_pages) = self.get_page_info();
         let page_idx = page.max(1).min(total_pages) - 1;
         let start_index = page_idx.saturating_mul(self.page_size);
-        let end_index = (page_idx + 1).min(total_pages).saturating_mul(self.page_size);
+        let end_index = (page_idx + 1)
+            .min(total_pages)
+            .saturating_mul(self.page_size);
         self.get_data_by_range(start_index, end_index)
     }
 
@@ -191,31 +203,40 @@ impl Store {
     }
 
     fn parse_selection_type(s: &str) -> Result<SelectorType, String> {
+        if s.trim().is_empty() {
+            return Err("Empty selector".to_string());
+        }
         if s == "all" {
             return Ok(SelectorType::All);
         }
         let mut indices = BTreeSet::new();
-        for s in s.split(',').map(|s| s.trim()) {
-            if s.is_empty() {
-                continue;
+        for part in s.split(',').map(|s| s.trim()) {
+            if part.is_empty() {
+                return Err("Empty selection component".to_string());
             }
-            if let Ok(index) = s.parse::<usize>() {
+            if let Ok(index) = part.parse::<usize>() {
                 indices.insert(index);
             } else {
-                let ranges: Vec<_> = s.split('-').map(|s| s.trim()).collect();
-                if ranges.len() > 2 {
-                    return Err(format!("Invalid range: {}", s));
-                } else {
-                    let start = ranges.get(0).unwrap_or(&"0").parse::<usize>().unwrap_or(0);
-                    let end = ranges.get(1).unwrap_or(&"0").parse::<usize>().unwrap_or(0);
-                    if start > end {
-                        return Err(format!("Invalid range: {}", s));
-                    }
-                    for i in start..=end {
-                        indices.insert(i);
-                    }
+                let ranges: Vec<_> = part.split('-').map(|s| s.trim()).collect();
+                if ranges.len() != 2 {
+                    return Err(format!("Invalid selection: {}", part));
+                }
+                let start = ranges[0]
+                    .parse::<usize>()
+                    .map_err(|_| format!("Invalid range start: {}", ranges[0]))?;
+                let end = ranges[1]
+                    .parse::<usize>()
+                    .map_err(|_| format!("Invalid range end: {}", ranges[1]))?;
+                if start > end {
+                    return Err(format!("Invalid range: {}", part));
+                }
+                for i in start..=end {
+                    indices.insert(i);
                 }
             }
+        }
+        if indices.is_empty() {
+            return Err("No valid indices parsed".to_string());
         }
         Ok(SelectorType::Indices(indices.into_iter().collect()))
     }
@@ -226,11 +247,9 @@ impl Store {
         }
         let selector_type = Store::parse_selection_type(selector);
         match selector_type {
-            Ok(selector_type) => {
-                match selector_type {
-                    SelectorType::Indices(indices) => self.get_multiple_data(&indices),
-                    SelectorType::All => self.get_all_data(),
-                }
+            Ok(selector_type) => match selector_type {
+                SelectorType::Indices(indices) => self.get_multiple_data(&indices),
+                SelectorType::All => self.get_all_data(),
             },
             Err(e) => Err(e),
         }
@@ -238,35 +257,31 @@ impl Store {
 
     pub fn sort(&mut self, sort_by: Option<&str>) {
         self.data.sort_by_key(|item| match sort_by {
-            Some("addr") => {
-                match item {
-                    VzData::Pointer(p) => p.address.to_string(),
-                    VzData::Module(m) => m.address.to_string(),
-                    VzData::Range(r) => r.address.to_string(),
-                    VzData::Function(f) => f.address.to_string(),
-                    VzData::Variable(v) => v.address.to_string(),
-                    VzData::JavaClass(c) => c.name.to_string(),
-                    VzData::JavaMethod(m) => m.name.to_string(),
-                    VzData::ObjCClass(c) => c.name.to_string(),
-                    VzData::ObjCMethod(m) => m.name.to_string(),
-                    VzData::Thread(t) => t.id.to_string(),
-                    _ => "".to_string(),
-                }
+            Some("addr") => match item {
+                VzData::Pointer(p) => p.address.to_string(),
+                VzData::Module(m) => m.address.to_string(),
+                VzData::Range(r) => r.address.to_string(),
+                VzData::Function(f) => f.address.to_string(),
+                VzData::Variable(v) => v.address.to_string(),
+                VzData::JavaClass(c) => c.name.to_string(),
+                VzData::JavaMethod(m) => m.name.to_string(),
+                VzData::ObjCClass(c) => c.name.to_string(),
+                VzData::ObjCMethod(m) => m.name.to_string(),
+                VzData::Thread(t) => t.id.to_string(),
+                _ => "".to_string(),
             },
-            _ | None => {
-                match item {
-                    VzData::Pointer(p) => p.address.to_string(),
-                    VzData::Module(m) => m.name.to_string(),
-                    VzData::Range(r) => r.address.to_string(),
-                    VzData::Function(f) => f.name.to_string(),
-                    VzData::Variable(v) => v.name.to_string(),
-                    VzData::JavaClass(c) => c.name.to_string(),
-                    VzData::JavaMethod(m) => m.name.to_string(),
-                    VzData::ObjCClass(c) => c.name.to_string(),
-                    VzData::ObjCMethod(m) => m.name.to_string(),
-                    VzData::Thread(f) => f.id.to_string(),
-                    _ => "".to_string(),
-                }
+            _ | None => match item {
+                VzData::Pointer(p) => p.address.to_string(),
+                VzData::Module(m) => m.name.to_string(),
+                VzData::Range(r) => r.address.to_string(),
+                VzData::Function(f) => f.name.to_string(),
+                VzData::Variable(v) => v.name.to_string(),
+                VzData::JavaClass(c) => c.name.to_string(),
+                VzData::JavaMethod(m) => m.name.to_string(),
+                VzData::ObjCClass(c) => c.name.to_string(),
+                VzData::ObjCMethod(m) => m.name.to_string(),
+                VzData::Thread(f) => f.id.to_string(),
+                _ => "".to_string(),
             },
         });
         self.adjust_cursor();
@@ -279,28 +294,40 @@ impl Store {
 
         let mut data = self.data.clone();
         data.retain(|item: &VzData| {
-            filter_segments.iter().all(|segment| {
-                match segment {
-                    FilterSegment::Condition(cond) => self.evaluate_condition_for_item(item, cond),
-                    FilterSegment::Logical(op) => match op {
-                        LogicalOperator::And => true,
-                        LogicalOperator::Or => false,
-                    },
-                }
+            filter_segments.iter().all(|segment| match segment {
+                FilterSegment::Condition(cond) => self.evaluate_condition_for_item(item, cond),
+                FilterSegment::Logical(op) => match op {
+                    LogicalOperator::And => true,
+                    LogicalOperator::Or => false,
+                },
             })
         });
         self.data = data;
         self.adjust_cursor();
     }
 
-    fn evaluate_condition_for_item(&self, vz_data_item: &VzData, condition: &super::filter::FilterCondition) -> bool {
-        if let Some(item_field_value) = self.get_field_value_for_filtering(vz_data_item, &condition.key) {
-            return self.compare_filter_values(&item_field_value, &condition.operator, &condition.value);
+    fn evaluate_condition_for_item(
+        &self,
+        vz_data_item: &VzData,
+        condition: &super::filter::FilterCondition,
+    ) -> bool {
+        if let Some(item_field_value) =
+            self.get_field_value_for_filtering(vz_data_item, &condition.key)
+        {
+            return self.compare_filter_values(
+                &item_field_value,
+                &condition.operator,
+                &condition.value,
+            );
         }
         false
     }
 
-    fn get_field_value_for_filtering(&self, vz_data_item: &VzData, key: &str) -> Option<FilterValue> {
+    fn get_field_value_for_filtering(
+        &self,
+        vz_data_item: &VzData,
+        key: &str,
+    ) -> Option<FilterValue> {
         match key.to_lowercase().as_str() {
             "name" => match vz_data_item {
                 VzData::Module(m) => Some(FilterValue::String(m.name.clone())),
@@ -321,8 +348,8 @@ impl Store {
                 _ => None,
             },
             "size" => match vz_data_item {
-                VzData::Module(m) => Some(FilterValue::Number(m.size as f64)),    // Assumes m.size is a newtype like Size(u64)
-                VzData::Range(r) => Some(FilterValue::Number(r.size as f64)),      // Assumes r.size is a newtype like Size(u64)
+                VzData::Module(m) => Some(FilterValue::Number(m.size as f64)), // Assumes m.size is a newtype like Size(u64)
+                VzData::Range(r) => Some(FilterValue::Number(r.size as f64)), // Assumes r.size is a newtype like Size(u64)
                 _ => None,
             },
             "protect" | "protection" => match vz_data_item {
@@ -330,20 +357,42 @@ impl Store {
                 _ => None,
             },
             "type" => match vz_data_item {
-                VzData::Pointer(p) => Some(FilterValue::String(format!("{:?}", p.base.data_type).to_lowercase())),
-                VzData::Module(m) => Some(FilterValue::String(format!("{:?}", m.base.data_type).to_lowercase())),
-                VzData::Range(r) => Some(FilterValue::String(format!("{:?}", r.base.data_type).to_lowercase())),
-                VzData::Function(f) => Some(FilterValue::String(format!("{:?}", f.base.data_type).to_lowercase())),
-                VzData::Variable(v) => Some(FilterValue::String(format!("{:?}", v.base.data_type).to_lowercase())),
-                VzData::JavaClass(jc) => Some(FilterValue::String(format!("{:?}", jc.base.data_type).to_lowercase())),
-                VzData::JavaMethod(jm) => Some(FilterValue::String(format!("{:?}", jm.base.data_type).to_lowercase())),
-                VzData::ObjCClass(oc) => Some(FilterValue::String(format!("{:?}", oc.base.data_type).to_lowercase())),
-                VzData::ObjCMethod(om) => Some(FilterValue::String(format!("{:?}", om.base.data_type).to_lowercase())),
-                VzData::Thread(t) => Some(FilterValue::String(format!("{:?}", t.base.data_type).to_lowercase())),
+                VzData::Pointer(p) => Some(FilterValue::String(
+                    format!("{:?}", p.base.data_type).to_lowercase(),
+                )),
+                VzData::Module(m) => Some(FilterValue::String(
+                    format!("{:?}", m.base.data_type).to_lowercase(),
+                )),
+                VzData::Range(r) => Some(FilterValue::String(
+                    format!("{:?}", r.base.data_type).to_lowercase(),
+                )),
+                VzData::Function(f) => Some(FilterValue::String(
+                    format!("{:?}", f.base.data_type).to_lowercase(),
+                )),
+                VzData::Variable(v) => Some(FilterValue::String(
+                    format!("{:?}", v.base.data_type).to_lowercase(),
+                )),
+                VzData::JavaClass(jc) => Some(FilterValue::String(
+                    format!("{:?}", jc.base.data_type).to_lowercase(),
+                )),
+                VzData::JavaMethod(jm) => Some(FilterValue::String(
+                    format!("{:?}", jm.base.data_type).to_lowercase(),
+                )),
+                VzData::ObjCClass(oc) => Some(FilterValue::String(
+                    format!("{:?}", oc.base.data_type).to_lowercase(),
+                )),
+                VzData::ObjCMethod(om) => Some(FilterValue::String(
+                    format!("{:?}", om.base.data_type).to_lowercase(),
+                )),
+                VzData::Thread(t) => Some(FilterValue::String(
+                    format!("{:?}", t.base.data_type).to_lowercase(),
+                )),
                 _ => None,
             },
             "value_type" => match vz_data_item {
-                VzData::Pointer(p) => Some(FilterValue::String(format!("{:?}", p.value_type).to_lowercase())),
+                VzData::Pointer(p) => Some(FilterValue::String(
+                    format!("{:?}", p.value_type).to_lowercase(),
+                )),
                 _ => None,
             },
             "id" => match vz_data_item {
@@ -374,8 +423,12 @@ impl Store {
             (FilterValue::String(s_item), FilterValue::String(s_filter)) => match op {
                 FilterOperator::Equal => s_item.eq_ignore_ascii_case(s_filter),
                 FilterOperator::NotEqual => !s_item.eq_ignore_ascii_case(s_filter),
-                FilterOperator::Contains => s_item.to_lowercase().contains(&s_filter.to_lowercase()),
-                FilterOperator::NotContains => !s_item.to_lowercase().contains(&s_filter.to_lowercase()),
+                FilterOperator::Contains => {
+                    s_item.to_lowercase().contains(&s_filter.to_lowercase())
+                }
+                FilterOperator::NotContains => {
+                    !s_item.to_lowercase().contains(&s_filter.to_lowercase())
+                }
                 FilterOperator::LessThan => s_item < s_filter,
                 FilterOperator::LessEqual => s_item <= s_filter,
                 FilterOperator::GreaterThan => s_item > s_filter,
@@ -397,19 +450,30 @@ impl Store {
             },
             (FilterValue::Number(n_item), FilterValue::String(s_filter)) => {
                 if let Ok(n_filter) = s_filter.parse::<f64>() {
-                    self.compare_filter_values(&FilterValue::Number(*n_item), op, &FilterValue::Number(n_filter))
-                } else { false }
+                    self.compare_filter_values(
+                        &FilterValue::Number(*n_item),
+                        op,
+                        &FilterValue::Number(n_filter),
+                    )
+                } else {
+                    false
+                }
             }
             (FilterValue::String(s_item), FilterValue::Number(n_filter)) => {
                 if let Ok(n_item) = s_item.parse::<f64>() {
-                    self.compare_filter_values(&FilterValue::Number(n_item), op, &FilterValue::Number(*n_filter))
-                } else { false }
+                    self.compare_filter_values(
+                        &FilterValue::Number(n_item),
+                        op,
+                        &FilterValue::Number(*n_filter),
+                    )
+                } else {
+                    false
+                }
             }
             _ => false,
         }
     }
 
-    
     pub fn to_string(&self, page: Option<usize>) -> String {
         let cursor = if self.data.len() > 0 {
             self.get_cursor()
@@ -417,7 +481,8 @@ impl Store {
             0
         };
         let (current_page, total_pages) = self.get_page_info();
-        let header = format!("{} {}-{} [{}] ({}/{})",
+        let header = format!(
+            "{} {}-{} [{}] ({}/{})",
             self.name.clone().green(),
             cursor,
             self.get_cursor_end(),
@@ -425,17 +490,23 @@ impl Store {
             current_page,
             total_pages
         );
-        let data = self.get_data_by_page(page.unwrap_or(current_page)).unwrap();
+        let data = match self.get_data_by_page(page.unwrap_or(current_page)) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("Page error: {}", e);
+                Vec::new()
+            }
+        };
         let max_idx_len = self.data.len().to_string().len();
         let mut body = String::new();
         for (i, item) in data.iter().enumerate() {
             let global_idx = self.get_cursor() + i;
-            body.push_str(&format!("\n[{}] {}",
+            body.push_str(&format!(
+                "\n[{}] {}",
                 format!("{:^width$}", global_idx, width = max_idx_len).blue(),
                 item
             ));
         }
         format!("{}{}", header, body)
     }
-
 }

--- a/src/gum/vzdata.rs
+++ b/src/gum/vzdata.rs
@@ -41,19 +41,32 @@ pub struct VzBase {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VzValueType {
-    Byte, Int8,
-    UByte, UInt8,
-    Short, Int16,
-    UShort, UInt16,
-    Int, Int32,
-    UInt, UInt32,
-    Long, Int64,
-    ULong, UInt64,
-    Float, Float32,
-    Double, Float64,
-    Bool, Boolean,
-    String, Utf8,
-    Array, Bytes,
+    Byte,
+    Int8,
+    UByte,
+    UInt8,
+    Short,
+    Int16,
+    UShort,
+    UInt16,
+    Int,
+    Int32,
+    UInt,
+    UInt32,
+    Long,
+    Int64,
+    ULong,
+    UInt64,
+    Float,
+    Float32,
+    Double,
+    Float64,
+    Bool,
+    Boolean,
+    String,
+    Utf8,
+    Array,
+    Bytes,
     Pointer,
     Void,
 }
@@ -121,7 +134,9 @@ pub struct VzPointer {
 
 impl fmt::Display for VzPointer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {} {} {}",
+        write!(
+            f,
+            "{} {} {} {}",
             format!("[{}]", self.base.data_type).blue(),
             format!("{:#x}", self.address).yellow(),
             format!("({:#x})", self.size).dark_grey(),
@@ -140,9 +155,15 @@ pub struct VzModule {
 
 impl fmt::Display for VzModule {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {} {}",
+        write!(
+            f,
+            "{} {} {}",
             format!("[{}]", self.base.data_type).blue(),
-            format!("{} @ {}", self.name, format!("{:#x}", self.address).yellow()),
+            format!(
+                "{} @ {}",
+                self.name,
+                format!("{:#x}", self.address).yellow()
+            ),
             format!("({:#x})", self.size).dark_grey()
         )
     }
@@ -171,9 +192,15 @@ pub struct VzRange {
 
 impl fmt::Display for VzRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {} {} {}",
+        write!(
+            f,
+            "{} {} {} {}",
             format!("[{}]", self.base.data_type).blue(),
-            format!("{:#x} - {:#x}", self.address, self.address + self.size as u64),
+            format!(
+                "{:#x} - {:#x}",
+                self.address,
+                self.address + self.size as u64
+            ),
             format!("({:#x})", self.size).dark_grey(),
             format!("[{}]", self.protection).yellow()
         )
@@ -203,9 +230,15 @@ pub struct VzFunction {
 
 impl fmt::Display for VzFunction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {} {}",
+        write!(
+            f,
+            "{} {} {}",
             format!("[{}]", self.base.data_type).blue(),
-            format!("{} @ {}", self.name, format!("{:#x}", self.address).yellow()),
+            format!(
+                "{} @ {}",
+                self.name,
+                format!("{:#x}", self.address).yellow()
+            ),
             format!("({})", self.module).yellow()
         )
     }
@@ -234,9 +267,15 @@ pub struct VzVariable {
 
 impl fmt::Display for VzVariable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {} {}",
+        write!(
+            f,
+            "{} {} {}",
             format!("[{}]", self.base.data_type).blue(),
-            format!("{} @ {}", self.name, format!("{:#x}", self.address).yellow()),
+            format!(
+                "{} @ {}",
+                self.name,
+                format!("{:#x}", self.address).yellow()
+            ),
             format!("({})", self.module).yellow()
         )
     }
@@ -263,7 +302,9 @@ pub struct VzJavaClass {
 
 impl fmt::Display for VzJavaClass {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {}",
+        write!(
+            f,
+            "{} {}",
             format!("[{}]", self.base.data_type).blue(),
             self.name
         )
@@ -281,7 +322,9 @@ pub struct VzJavaMethod {
 
 impl fmt::Display for VzJavaMethod {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {}{} -> {} @ {}",
+        write!(
+            f,
+            "{} {}{} -> {} @ {}",
             format!("[{}]", self.base.data_type).blue(),
             self.name,
             format!("({})", self.args.join(", ")).yellow(),
@@ -299,7 +342,9 @@ pub struct VzObjCClass {
 
 impl fmt::Display for VzObjCClass {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {}",
+        write!(
+            f,
+            "{} {}",
             format!("[{}]", self.base.data_type).blue(),
             self.name
         )
@@ -315,7 +360,9 @@ pub struct VzObjCMethod {
 
 impl fmt::Display for VzObjCMethod {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {} @ {}",
+        write!(
+            f,
+            "{} {} @ {}",
             format!("[{}]", self.base.data_type).blue(),
             self.name,
             format!("({})", self.class).yellow()
@@ -331,14 +378,16 @@ pub struct VzThread {
 
 impl fmt::Display for VzThread {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {}",
+        write!(
+            f,
+            "{} {}",
             format!("[{}]", self.base.data_type).blue(),
             self.id,
         )
     }
 }
 
-pub fn string_to_u64(s: &str) -> u64 {
+pub fn string_to_u64(s: &str) -> Result<u64, String> {
     let s = s.trim_start_matches("0x");
-    u64::from_str_radix(s, 16).unwrap()
+    u64::from_str_radix(s, 16).map_err(|_| format!("Invalid hex string: {}", s))
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,7 +5,7 @@ pub fn lengthed(s: &str, size: usize) -> String {
     // Strip ANSI color codes for length calculation
     let stripped = strip_ansi_escapes::strip(s);
     let stripped_str = String::from_utf8_lossy(&stripped);
-    
+
     let len = stripped_str.graphemes(true).count();
     if len == size {
         s.to_string()
@@ -13,7 +13,7 @@ pub fn lengthed(s: &str, size: usize) -> String {
         let mut result = String::new();
         let mut current_len = 0;
         let ellipsis = "…";
-        
+
         // Rebuild the string with color codes but proper length
         for c in s.chars() {
             if current_len >= size - 1 {
@@ -25,7 +25,9 @@ pub fn lengthed(s: &str, size: usize) -> String {
                 // Skip ANSI escape sequence
                 while let Some(next) = s.chars().nth(result.len()) {
                     result.push(next);
-                    if next == 'm' { break; }
+                    if next == 'm' {
+                        break;
+                    }
                 }
             } else {
                 current_len += 1;
@@ -44,7 +46,7 @@ pub fn fill(length: usize) -> String {
 pub fn highlight(s: &str, filter: &str) -> String {
     let mut highlighted = String::new();
     let mut start = 0;
-    
+
     while let Some(pos) = s.to_lowercase()[start..].find(&filter.to_lowercase()) {
         let mut end = 0;
         end = start + pos;
@@ -55,4 +57,8 @@ pub fn highlight(s: &str, filter: &str) -> String {
     highlighted.push_str(&s[start..]);
 
     highlighted
+}
+
+pub fn log_error(msg: &str) {
+    eprintln!("{}", msg.red());
 }


### PR DESCRIPTION
## Summary
- add `log_error` helper
- tighten selector parsing in `Store`
- validate page inputs and list operations in commander
- fix navigator save logic and error handling
- propagate address parsing errors in list helpers

## Testing
- `cargo build --quiet` *(fails: frida devkit download)*

------
https://chatgpt.com/codex/tasks/task_e_6846dc75fe8c832a97ee4a41538886d9